### PR TITLE
nested draw handling

### DIFF
--- a/app/components/tic-tac-toe-board/board.test.tsx
+++ b/app/components/tic-tac-toe-board/board.test.tsx
@@ -40,81 +40,85 @@ const _4b: BoardState = [
 ] as const
 
 describe('board core', () => {
-  it('allows players to take turns', async () => {
-    render(<Board />)
+  describe('take turns', () => {
+    it('allows players to take turns', async () => {
+      render(<Board />)
 
-    const cells = screen.getAllByRole('button')
-    expect(cells.length).toBe(9)
+      const cells = screen.getAllByRole('button')
+      expect(cells.length).toBe(9)
 
-    await userEvent.click(cells[0])
-    expect(cells[0]).toHaveTextContent('X')
+      await userEvent.click(cells[0])
+      expect(cells[0]).toHaveTextContent('X')
 
-    await userEvent.click(cells[1])
-    expect(cells[1]).toHaveTextContent('O')
-  })
-
-  it('doesn\'t allow players to click used cells', async () => {
-    render(<Board />)
-
-    const cells = screen.getAllByRole('button')
-    expect(cells.length).toBe(9)
-
-    await userEvent.click(cells[0])
-    expect(cells[0]).toHaveTextContent('X')
-
-    // Click the same cell, nothing happens
-    await userEvent.click(cells[0])
-    expect(cells[0]).toHaveTextContent('X')
-
-    // O still gets their turn
-    await userEvent.click(cells[1])
-    expect(cells[1]).toHaveTextContent('O')
-  })
-
-  it('doesn\'t show deep state fully', () => {
-    useGameStore.setState({ boardState: _4b })
-    render(<Board />)
-
-    const cells = screen.getAllByRole('region', { name: /unknown state/i })
-    // Not rendering sub-boards past level 3
-    expect(cells.length).toBe(9 ** 3)
-
-    for (const cell of cells) {
-      expect(cell.textContent).toBe('?')
-    }
-  })
-
-  it('shows the cell summary for completed boards at the render boundary', () => {
-    /** Mostly all blank 2 level board, but with the top left sub-board completed */
-    const p2b: BoardState = [
-      x1b, _1b, _1b,
-      _1b, _1b, _1b,
-      _1b, _1b, _1b,
-    ] as const
-    /** Mostly all blank 3 level board, but with the top left sub-board completed */
-    const p3b: BoardState = [
-      p2b, _2b, _2b,
-      _2b, _2b, _2b,
-      _2b, _2b, _2b,
-    ] as const
-    useGameStore.setState({
-      boardState: [
-        p3b, _3b, _3b,
-        _3b, _3b, _3b,
-        _3b, _3b, _3b,
-      ],
+      await userEvent.click(cells[1])
+      expect(cells[1]).toHaveTextContent('O')
     })
-    render(<Board />)
 
-    const unknownCells = screen.getAllByRole('region', { name: /unknown state/i })
-    // Not rendering sub-boards past level 3
-    expect(unknownCells.length).toBe(9 ** 3 - 1)
+    it('doesn\'t allow players to click used cells', async () => {
+      render(<Board />)
 
-    for (const cell of unknownCells) {
-      expect(cell.textContent).toBe('?')
-    }
+      const cells = screen.getAllByRole('button')
+      expect(cells.length).toBe(9)
 
-    const completedCells = screen.getAllByRole('region', { name: /board won by X/i })
-    expect(completedCells.length).toBe(1)
+      await userEvent.click(cells[0])
+      expect(cells[0]).toHaveTextContent('X')
+
+      // Click the same cell, nothing happens
+      await userEvent.click(cells[0])
+      expect(cells[0]).toHaveTextContent('X')
+
+      // O still gets their turn
+      await userEvent.click(cells[1])
+      expect(cells[1]).toHaveTextContent('O')
+    })
+  })
+
+  describe('deep state', () => {
+    it('doesn\'t show deep state fully', () => {
+      useGameStore.setState({ boardState: _4b })
+      render(<Board />)
+
+      const cells = screen.getAllByRole('region', { name: /unknown state/i })
+      // Not rendering sub-boards past level 3
+      expect(cells.length).toBe(9 ** 3)
+
+      for (const cell of cells) {
+        expect(cell.textContent).toBe('?')
+      }
+    })
+
+    it('shows the cell summary for completed boards at the render boundary', () => {
+      /** Mostly all blank 2 level board, but with the top left sub-board completed */
+      const p2b: BoardState = [
+        x1b, _1b, _1b,
+        _1b, _1b, _1b,
+        _1b, _1b, _1b,
+      ] as const
+      /** Mostly all blank 3 level board, but with the top left sub-board completed */
+      const p3b: BoardState = [
+        p2b, _2b, _2b,
+        _2b, _2b, _2b,
+        _2b, _2b, _2b,
+      ] as const
+      useGameStore.setState({
+        boardState: [
+          p3b, _3b, _3b,
+          _3b, _3b, _3b,
+          _3b, _3b, _3b,
+        ],
+      })
+      render(<Board />)
+
+      const unknownCells = screen.getAllByRole('region', { name: /unknown state/i })
+      // Not rendering sub-boards past level 3
+      expect(unknownCells.length).toBe(9 ** 3 - 1)
+
+      for (const cell of unknownCells) {
+        expect(cell.textContent).toBe('?')
+      }
+
+      const completedCells = screen.getAllByRole('region', { name: /board won by X/i })
+      expect(completedCells.length).toBe(1)
+    })
   })
 })

--- a/app/components/tic-tac-toe-board/board.test.tsx
+++ b/app/components/tic-tac-toe-board/board.test.tsx
@@ -20,6 +20,12 @@ const x1b: BoardState = [
   O, O, _,
   _, _, _,
 ] as const
+/** 1 level board won by O */
+const o1b: BoardState = [
+  X, X, _,
+  O, O, O,
+  _, _, X,
+] as const
 /** All blank 2 level board */
 const _2b: BoardState = [
   _1b, _1b, _1b,
@@ -70,6 +76,48 @@ describe('board core', () => {
       // O still gets their turn
       await userEvent.click(cells[1])
       expect(cells[1]).toHaveTextContent('O')
+    })
+  })
+
+  describe('nested cell summaries', () => {
+    it('summarises sub-boards won by X', () => {
+      useGameStore.setState({
+        boardState: [
+          _1b, x1b, _1b,
+          _1b, _1b, _1b,
+          _1b, _1b, _1b,
+        ],
+      })
+      render(<Board />)
+
+      const xSubBoard = screen.getByRole('region', { name: /sub-board won by X/i })
+      expect(xSubBoard).toBeInTheDocument()
+      const emptySubBoards = screen.getAllByRole('region', { name: /in-progress sub-board/i })
+      expect(emptySubBoards.length).toBe(8)
+    })
+
+    it('summarises sub-boards won by O', () => {
+      useGameStore.setState({
+        boardState: [
+          _1b, o1b, _1b,
+          _1b, _1b, _1b,
+          _1b, _1b, _1b,
+        ],
+      })
+      render(<Board />)
+
+      const xSubBoard = screen.getByRole('region', { name: /sub-board won by O/i })
+      expect(xSubBoard).toBeInTheDocument()
+      const emptySubBoards = screen.getAllByRole('region', { name: /in-progress sub-board/i })
+      expect(emptySubBoards.length).toBe(8)
+    })
+
+    it('does not summarise the top level board', () => {
+      useGameStore.setState({ boardState: x1b })
+      render(<Board />)
+
+      const cells = screen.getAllByRole('button', { name: /cell/i })
+      expect(cells.length).toBe(9)
     })
   })
 

--- a/app/components/tic-tac-toe-board/board.test.tsx
+++ b/app/components/tic-tac-toe-board/board.test.tsx
@@ -26,6 +26,12 @@ const o1b: BoardState = [
   O, O, O,
   _, _, X,
 ] as const
+/** 1 level drawn board */
+const d1b: BoardState = [
+  X, X, O,
+  O, O, X,
+  X, O, X,
+] as const
 /** All blank 2 level board */
 const _2b: BoardState = [
   _1b, _1b, _1b,
@@ -108,6 +114,22 @@ describe('board core', () => {
 
       const xSubBoard = screen.getByRole('region', { name: /sub-board won by O/i })
       expect(xSubBoard).toBeInTheDocument()
+      const emptySubBoards = screen.getAllByRole('region', { name: /in-progress sub-board/i })
+      expect(emptySubBoards.length).toBe(8)
+    })
+
+    it('summarises drawn sub-boards', () => {
+      useGameStore.setState({
+        boardState: [
+          _1b, d1b, _1b,
+          _1b, _1b, _1b,
+          _1b, _1b, _1b,
+        ],
+      })
+      render(<Board />)
+
+      const drawnSubBoard = screen.getByRole('region', { name: /sub-board drawn/i })
+      expect(drawnSubBoard).toBeInTheDocument()
       const emptySubBoards = screen.getAllByRole('region', { name: /in-progress sub-board/i })
       expect(emptySubBoards.length).toBe(8)
     })

--- a/app/components/tic-tac-toe-board/board.tsx
+++ b/app/components/tic-tac-toe-board/board.tsx
@@ -34,15 +34,15 @@ export default function Board({ cellPath = [], disabled = null }: Props) {
   const win = findWin(boardState)
   const winCells = win ? win.cells : null
 
-  const showWinSummary = win && cellPath.length > 0
+  const showSummary = win !== null && cellPath.length > 0
   const showUnknown = cellPath.length >= maxDisplayDepth
 
-  if (showWinSummary || showUnknown) {
+  if (showSummary || showUnknown) {
     return (
       <section
         aria-label={
-          showWinSummary
-            ? `sub-board won by ${win.player}`
+          showSummary
+            ? `sub-board ${win ? `won by ${win.player}` : 'drawn'}`
             : 'sub-board with unknown state'
         }
         className="size-full"
@@ -50,8 +50,13 @@ export default function Board({ cellPath = [], disabled = null }: Props) {
         // Mimic this for this summary by adding 1px of real padding per level this summarises
         style={{ padding: displayDepth }}
       >
-        <div className={classNames('size-full', showWinSummary ? 'bg-green-500' : 'bg-gray-400')}>
-          {(win || null)?.player ?? '?'}
+        <div
+          className={classNames(
+            'size-full',
+            showSummary && win ? 'bg-green-500' : 'bg-gray-400',
+          )}
+        >
+          {showSummary ? (win || null)?.player ?? '-' : '?'}
         </div>
       </section>
     )

--- a/app/components/tic-tac-toe-board/index.test.tsx
+++ b/app/components/tic-tac-toe-board/index.test.tsx
@@ -62,6 +62,12 @@ const x2b: BoardState = [
   _1b, _1b, _1b,
   _1b, _1b, _1b,
 ] as const
+/** 1 level drawn board */
+const d1b: BoardState = [
+  X, X, O,
+  O, O, X,
+  X, O, X,
+] as const
 
 describe('game board', () => {
   const performWin = async () => {
@@ -373,6 +379,50 @@ describe('game board', () => {
 
       const wonSubBoard = screen.getByRole('region', { name: /sub-board won/i })
       expect(wonSubBoard).toBeInTheDocument()
+      const emptyCells = screen.getAllByRole('region', { name: /empty cell/i })
+      expect(emptyCells.length).toBe(9 * 9 * 8)
+    })
+
+    it('zooms out when visible sub-board is drawn', async () => {
+      /** 1 level board that's almost a draw */
+      const a1b: BoardState = [
+        X, O, _,
+        O, X, X,
+        O, X, O,
+      ] as const
+      /** 2 level board that's almost a draw */
+      const a2b: BoardState = [
+        d1b, d1b, a1b,
+        d1b, d1b, d1b,
+        d1b, d1b, d1b,
+      ] as const
+
+      // set up 3 level board that has a 2 level board that is almost a draw
+      useGameStore.setState({
+        boardState: [
+          a2b, _2b, _2b,
+          _2b, _2b, _2b,
+          _2b, _2b, _2b,
+        ] as const,
+      })
+      render(<TicTacToeBoard />)
+
+      // zoom into the almost drawn 2 level board
+      const subBoards = screen.getAllByRole('button')
+      expect(subBoards.length).toBe(9)
+      await userEvent.click(subBoards[0])
+
+      // draw the almost drawn 2 level board
+      const buttonCells = screen.getAllByRole('button', { name: /cell/i })
+      expect(buttonCells.length).toBe(9)
+      await userEvent.click(buttonCells[2])
+
+      // check we zoomed out automatically
+      const zoomOutButton = screen.queryByText(/zoom out/i)
+      expect(zoomOutButton).not.toBeInTheDocument()
+
+      const drawnSubBoard = screen.getByRole('region', { name: /sub-board drawn/i })
+      expect(drawnSubBoard).toBeInTheDocument()
       const emptyCells = screen.getAllByRole('region', { name: /empty cell/i })
       expect(emptyCells.length).toBe(9 * 9 * 8)
     })

--- a/app/components/tic-tac-toe-board/store/dev-tools-slice.ts
+++ b/app/components/tic-tac-toe-board/store/dev-tools-slice.ts
@@ -17,27 +17,54 @@ const generateSingleLevelBoardForCondition = (condition: BoardCondition): Single
   return state
 }
 
-const nullConditions = [BoardCondition.Empty, BoardCondition.InProgress] as const
+const homogenousConditions = [BoardCondition.Empty, BoardCondition.Drawn] as const
+const nullConditions = [
+  BoardCondition.Empty,
+  BoardCondition.InProgress,
+  BoardCondition.Drawn,
+] as const
 
 const generateBoardForCondition = (condition: BoardCondition, depth: number): BoardState => {
   if (depth < 1) throw new Error('Depth must be 1 or greater')
 
-  const baseBoard = generateSingleLevelBoardForCondition(condition)
-  if (depth === 1) return baseBoard
+  if (depth === 1) return generateSingleLevelBoardForCondition(condition)
 
-  const board = baseBoard.map((c) => {
-    switch (c) {
-      case FilledCellState.X:
-        return generateBoardForCondition(BoardCondition.WonX, depth - 1)
-      case FilledCellState.O:
-        return generateBoardForCondition(BoardCondition.WonO, depth - 1)
-      case null:
-        return generateBoardForCondition(
-          condition === BoardCondition.Empty ? condition : randomElement(nullConditions),
-          depth - 1,
-        )
-    }
-  })
+  let board
+  if (homogenousConditions.includes(condition)) {
+    // All the sub-boards will have the exact same condition
+    board = Array.from(Array(9)).map(() => generateBoardForCondition(condition, depth - 1))
+  } else {
+    // Generate a board for this level, and replace each of its cells with a sub-board with the
+    // appropriate result
+    const baseBoard = generateSingleLevelBoardForCondition(condition)
+
+    const maxDrawnBoards = condition === BoardCondition.InProgress
+      ? baseBoard.filter(c => c === null).length - 1
+      : Infinity
+    let totalDrawnBoards = 0
+
+    board = baseBoard.map((c) => {
+      switch (c) {
+        case FilledCellState.X:
+          return generateBoardForCondition(BoardCondition.WonX, depth - 1)
+        case FilledCellState.O:
+          return generateBoardForCondition(BoardCondition.WonO, depth - 1)
+        case null:
+          let subCondition = randomElement(nullConditions)
+
+          // We're generating an in-progress board, but we're about to cause a draw instead. Force
+          // the sub-condition to not be drawn to avoid that
+          // It's more likely than you might think
+          if (totalDrawnBoards === maxDrawnBoards && subCondition === BoardCondition.Drawn) {
+            subCondition = randomElement([BoardCondition.Empty, BoardCondition.InProgress])
+          }
+
+          if (subCondition === BoardCondition.Drawn) totalDrawnBoards++
+
+          return generateBoardForCondition(subCondition, depth - 1)
+      }
+    })
+  }
 
   assertIsBoardState(board)
   return board

--- a/app/components/tic-tac-toe-board/store/index.test.ts
+++ b/app/components/tic-tac-toe-board/store/index.test.ts
@@ -191,7 +191,7 @@ describe('game store dev tools', () => {
     return isBoardEmpty(cell)
   }, true)
 
-  it.for([
+  const itForEachConditionAndDepth = it.for([
     [BoardCondition.Empty, 1],
     [BoardCondition.Empty, 2],
     [BoardCondition.Empty, 3],
@@ -207,37 +207,42 @@ describe('game store dev tools', () => {
     [BoardCondition.WonO, 1],
     [BoardCondition.WonO, 2],
     [BoardCondition.WonO, 3],
-  ] as const)('can generate a %s %i level board state', ([condition, depth]) => {
-    const forceBoardCondition = useGameStore.getState().forceBoardCondition
-    forceBoardCondition(condition, depth)
+  ] as const)
+  itForEachConditionAndDepth(
+    'can generate a %s %i level board state',
+    { repeats: 50 },
+    ([condition, depth]) => {
+      const forceBoardCondition = useGameStore.getState().forceBoardCondition
+      forceBoardCondition(condition, depth)
 
-    const boardState = useGameStore.getState().boardState
-    const win = findWin(boardState)
+      const boardState = useGameStore.getState().boardState
+      const win = findWin(boardState)
 
-    expect(calcDepth(boardState)).toBe(depth)
+      expect(calcDepth(boardState)).toBe(depth)
 
-    switch (condition) {
-      case BoardCondition.Empty:
-        expect(win).toBe(null)
-        expect(isBoardEmpty(boardState)).toBe(true)
-        break
+      switch (condition) {
+        case BoardCondition.Empty:
+          expect(win).toBe(null)
+          expect(isBoardEmpty(boardState)).toBe(true)
+          break
 
-      case BoardCondition.InProgress:
-        expect(win).toBe(null)
-        expect(isBoardEmpty(boardState)).toBe(false)
-        break
+        case BoardCondition.InProgress:
+          expect(win).toBe(null)
+          expect(isBoardEmpty(boardState)).toBe(false)
+          break
 
-      case BoardCondition.Drawn:
-        expect(win).toBe(false)
-        break
+        case BoardCondition.Drawn:
+          expect(win).toBe(false)
+          break
 
-      case BoardCondition.WonX:
-        expect((win || null)?.player).toBe(FilledCellState.X)
-        break
+        case BoardCondition.WonX:
+          expect((win || null)?.player).toBe(FilledCellState.X)
+          break
 
-      case BoardCondition.WonO:
-        expect((win || null)?.player).toBe(FilledCellState.O)
-        break
-    }
-  })
+        case BoardCondition.WonO:
+          expect((win || null)?.player).toBe(FilledCellState.O)
+          break
+      }
+    },
+  )
 })

--- a/app/components/tic-tac-toe-board/utils.test.ts
+++ b/app/components/tic-tac-toe-board/utils.test.ts
@@ -46,14 +46,14 @@ describe('win finder', () => {
       ],
       // O
       [
-        O, _, O,
-        O, X, _,
+        O, O, O,
+        _, X, _,
         _, X, X,
       ],
       // O
       [
-        O, _, O,
-        O, X, _,
+        O, O, O,
+        _, X, _,
         _, X, X,
       ],
       // X

--- a/app/components/tic-tac-toe-board/utils.test.ts
+++ b/app/components/tic-tac-toe-board/utils.test.ts
@@ -107,4 +107,126 @@ describe('win finder', () => {
 
     expect(findWin(board)).toBe(false)
   })
+
+  it('allows for draws in sub-boards', () => {
+    const board: BoardState = [
+      // _
+      [
+        _, _, _,
+        _, _, _,
+        _, _, _,
+      ],
+      // d
+      [
+        O, X, O,
+        O, X, X,
+        X, O, X,
+      ],
+      // _
+      [
+        _, _, _,
+        _, _, _,
+        _, _, _,
+      ],
+      // _
+      [
+        _, _, _,
+        _, _, _,
+        _, _, _,
+      ],
+      // _
+      [
+        _, _, _,
+        _, _, _,
+        _, _, _,
+      ],
+      // _
+      [
+        _, _, _,
+        _, _, _,
+        _, _, _,
+      ],
+      // _
+      [
+        _, _, _,
+        _, _, _,
+        _, _, _,
+      ],
+      // _
+      [
+        _, _, _,
+        _, _, _,
+        _, _, _,
+      ],
+      // _
+      [
+        _, _, _,
+        _, _, _,
+        _, _, _,
+      ],
+    ]
+
+    expect(findWin(board)).toBeNull()
+  })
+
+  it('finds nested draws', () => {
+    const board: BoardState = [
+      // d
+      [
+        O, X, O,
+        O, X, X,
+        X, O, X,
+      ],
+      // d
+      [
+        O, X, O,
+        O, X, X,
+        X, O, X,
+      ],
+      // d
+      [
+        O, X, O,
+        O, X, X,
+        X, O, X,
+      ],
+      // d
+      [
+        O, X, O,
+        O, X, X,
+        X, O, X,
+      ],
+      // d
+      [
+        O, X, O,
+        O, X, X,
+        X, O, X,
+      ],
+      // d
+      [
+        O, X, O,
+        O, X, X,
+        X, O, X,
+      ],
+      // d
+      [
+        O, X, O,
+        O, X, X,
+        X, O, X,
+      ],
+      // d
+      [
+        O, X, O,
+        O, X, X,
+        X, O, X,
+      ],
+      // d
+      [
+        O, X, O,
+        O, X, X,
+        X, O, X,
+      ],
+    ]
+
+    expect(findWin(board)).toBe(false)
+  })
 })

--- a/app/components/tic-tac-toe-board/utils.ts
+++ b/app/components/tic-tac-toe-board/utils.ts
@@ -47,7 +47,7 @@ export const findWin = (board: BoardState): Win | null | false => {
     const i = Number(k)
     const cell = resolveCellState(board[i])
 
-    if (cell === false) return false
+    if (cell === false) continue
 
     if (cell === null) {
       movesAvailable = true


### PR DESCRIPTION
- **Grouped some tests**
- **Fixed some slightly incorrect tests**
- **Added some missing tests**
- **Win finder now allows for draws in sub-boards**
- **Board now summarises drawn sub-boards**
- **Added test for zooming out of drawn sub-boards**
- **Dev tools can now include drawn sub-boards in generated boards**
